### PR TITLE
When id in dataSource object is a number Warning appears

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,51 +53,51 @@ export default class App extends Component {
     this.state = {
       dataSource: [
         {
-          id: 1,
+          id: "1",
           name: "Afghanistan"
         },
         {
-          id: 2,
+          id: "2",
           name: "Bahrain"
         },
         {
-          id: 3,
+          id: "3",
           name: "Canada"
         },
         {
-          id: 4,
+          id: "4",
           name: "Denmark"
         },
         {
-          id: 5,
+          id: "5",
           name: "Egypt"
         },
         {
-          id: 6,
+          id: "6",
           name: "France"
         },
         {
-          id: 7,
+          id: "7",
           name: "Greece"
         },
         {
-          id: 8,
+          id: "8",
           name: "Hong Kong"
         },
         {
-          id: 9,
+          id: "9",
           name: "India"
         },
         {
-          id: 10,
+          id: "10",
           name: "Japan"
         },
         {
-          id: 11,
+          id: "11",
           name: "Kenya"
         },
         {
-          id: 12,
+          id: "12",
           name: "Liberia"
         }
       ],


### PR DESCRIPTION
When id prop in dataSource object is a number the console shows the following number

- Warning: Failed child context type: Invalid child context virtualizedCell.cellKey of type number supplied to CellRenderer, expected string.

if you change the id to a string (id: "1") the warning disappears.